### PR TITLE
Dome cell

### DIFF
--- a/examples/plot_supported_np.py
+++ b/examples/plot_supported_np.py
@@ -1,0 +1,109 @@
+"""Render a supported-nanoparticle GCMC trajectory frame as a showcase figure.
+
+A single 3/4 view with depth shading (atoms farther from the viewer are
+darkened) so the particle reads as sitting on the support instead of pasted
+onto it. Adsorbed atoms are identified as those appended after the initial
+structure: the first frame of the trajectory is the clean (pre-adsorption)
+system, so any atom whose index is >= ``len(frame0)`` was inserted by GCMC.
+This is robust to deletions because insertions are appended at the end and the
+support is never deleted.
+
+Needs matplotlib and ase (e.g. ``conda run -n base python ...``).
+
+Usage::
+
+    python examples/plot_supported_np.py traj.xyz --out figure.png
+    python examples/plot_supported_np.py traj.xyz --particle-species Ag --frame -1
+"""
+import argparse
+
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt  # noqa: E402
+import matplotlib.patches as mpatches  # noqa: E402
+from ase.io import read  # noqa: E402
+from ase.io.utils import rotate  # noqa: E402
+from ase.visualize.plot import plot_atoms  # noqa: E402
+
+# role -> (base rgb, draw radius)
+AG = (0.74, 0.77, 0.83)
+SUPPORT_METAL = (0.82, 0.73, 0.55)
+SUPPORT_O = (0.93, 0.80, 0.80)
+ADSORBED = (0.90, 0.07, 0.07)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('trajectory', help='Extended-XYZ GCMC trajectory')
+    p.add_argument('--out', default='supported_np.png', help='Output PNG path')
+    p.add_argument('--particle-species', default='Ag',
+                   help='Symbol of the nanoparticle metal (coloured silver)')
+    p.add_argument('--frame', type=int, default=-1, help='Frame index to render')
+    p.add_argument('--rotation', default='-80x,-15y,0z', help='ASE view rotation')
+    p.add_argument('--dpi', type=int, default=200)
+    return p.parse_args()
+
+
+def atom_styles(atoms, n_initial, particle_species):
+    """Per-atom base colours and draw radii, keyed on role."""
+    symbols = np.array(atoms.get_chemical_symbols())
+    n = len(atoms)
+    colors = np.zeros((n, 3))
+    radii = np.zeros(n)
+    for i in range(n):
+        if i >= n_initial:                       # appended by GCMC = adsorbed
+            colors[i], radii[i] = ADSORBED, 0.66
+        elif symbols[i] == particle_species:
+            colors[i], radii[i] = AG, 1.44
+        elif symbols[i] == 'O':
+            colors[i], radii[i] = SUPPORT_O, 0.40
+        else:
+            colors[i], radii[i] = SUPPORT_METAL, 0.66
+    return colors, radii
+
+
+def depth_shade(colors, atoms, rotation):
+    """Darken atoms by their depth along the view direction (fake volume)."""
+    depth = atoms.positions @ rotate(rotation)
+    z = depth[:, 2]
+    norm = (z - z.min()) / (np.ptp(z) + 1e-9)    # 0 = far, 1 = near
+    return colors * (0.40 + 0.60 * norm)[:, None], np.argsort(z)
+
+
+def main():
+    args = parse_args()
+    n_initial = len(read(args.trajectory, index=0))
+    atoms = read(args.trajectory, index=args.frame)
+    n_ads = len(atoms) - n_initial
+
+    colors, radii = atom_styles(atoms, n_initial, args.particle_species)
+    colors, order = depth_shade(colors, atoms, args.rotation)   # far drawn first
+
+    fig, ax = plt.subplots(figsize=(8.5, 8))
+    plot_atoms(atoms[order], ax, colors=colors[order], radii=radii[order],
+               rotation=args.rotation, show_unit_cell=0)
+    for patch in ax.patches:                     # soften the cartoon outlines
+        fc = patch.get_facecolor()
+        patch.set_edgecolor((fc[0] * 0.55, fc[1] * 0.55, fc[2] * 0.55))
+        patch.set_linewidth(0.25)
+    ax.set_axis_off()
+    ax.set_aspect('equal')
+    ax.set_title(f'O on Al$_2$O$_3$-supported {args.particle_species} nanoparticle  '
+                 f'|  {n_ads} adsorbed', fontsize=13)
+
+    handles = [
+        mpatches.Patch(color=AG, label=f'{args.particle_species} (nanoparticle)'),
+        mpatches.Patch(color=SUPPORT_METAL, label='support metal'),
+        mpatches.Patch(color=SUPPORT_O, label='support O'),
+        mpatches.Patch(color=ADSORBED, label='adsorbed'),
+    ]
+    ax.legend(handles=handles, loc='upper right', frameon=False, fontsize=10)
+    fig.tight_layout()
+    fig.savefig(args.out, dpi=args.dpi, facecolor='white')
+    print(f'saved {args.out}  ({n_ads} adsorbed atoms, frame {args.frame})')
+
+
+if __name__ == '__main__':
+    main()

--- a/mcpy/cell/__init__.py
+++ b/mcpy/cell/__init__.py
@@ -2,5 +2,6 @@ from .cell import Cell
 from .null_cell import NullCell
 from .custom_cell import CustomCell
 from .spherical_cell import SphericalCell
+from .dome_cell import DomeCell
 
-__all__ = ["Cell", "NullCell", "CustomCell", "SphericalCell"]
+__all__ = ["Cell", "NullCell", "CustomCell", "SphericalCell", "DomeCell"]

--- a/mcpy/cell/dome_cell.py
+++ b/mcpy/cell/dome_cell.py
@@ -1,0 +1,141 @@
+import numpy as np
+from scipy.spatial import cKDTree
+
+from .cell import Cell
+from .spherical_cell import SphericalCell
+
+
+class DomeCell(SphericalCell):
+    """A hemispherical ('dome') insertion region centered on a supported particle.
+
+    The region is the ball of radius ``R`` around the particle centroid,
+    truncated at the support surface (``z >= bottom_z``). It differs from
+    :class:`SphericalCell` in two ways that matter for a supported nanoparticle:
+
+    - it centers on a chosen *particle* species (e.g. the metal) rather than on
+      the whole-system center of mass, so the dome sits on the nanoparticle and
+      not on the support slab;
+    - it does not translate the atoms, and it clips the region at the support
+      surface.
+
+    The result is that trial insertions land on and around the particle (and its
+    metal-support contact rim) instead of spreading across the bare support.
+    """
+
+    def __init__(self, atoms, particle_species, bottom_z, vacuum,
+                 species_radii, mc_sample_points: int = 100_000, seed=None):
+        """
+        :param atoms: ASE Atoms object (support + particle).
+        :param particle_species: Symbol or list of symbols identifying the
+                                 nanoparticle (e.g. ``'Ag'``). Used to locate the
+                                 dome center and radius.
+        :param bottom_z: z-coordinate of the support surface; the region is
+                         clipped to ``z >= bottom_z``.
+        :param vacuum: Padding added to the particle bounding radius.
+        :param species_radii: Dict mapping atom symbols to radii (free-volume
+                              exclusion).
+        :param mc_sample_points: Number of random points used to estimate the
+                                 free volume.
+        :param seed: Optional seed for the cell-local numpy RNG.
+        """
+        # Initialise the base Cell directly: SphericalCell.__init__ would move the
+        # atoms to their center of mass, which is wrong for a supported slab.
+        Cell.__init__(self, atoms, species_radii=species_radii, seed=seed)
+
+        if isinstance(particle_species, str):
+            particle_species = [particle_species]
+        symbols = np.asarray(atoms.get_chemical_symbols())
+        particle_mask = np.isin(symbols, particle_species)
+        if not particle_mask.any():
+            raise ValueError(
+                f'No atoms of particle_species={particle_species} found in the cell.'
+            )
+
+        particle_pos = atoms.positions[particle_mask]
+        self.center = particle_pos.mean(axis=0)
+        self.bottom_z = float(bottom_z)
+        self.radius = float(
+            np.linalg.norm(particle_pos - self.center, axis=1).max() + vacuum
+        )
+        self.species_radii = species_radii
+        self.mc_sample_points = int(mc_sample_points)
+        self.sphere_volume = (4.0 / 3.0) * np.pi * (self.radius ** 3)
+        self.volume = self.sphere_volume
+
+    def is_point_inside(self, point):
+        """Inside the ball and at or above the support surface."""
+        if point[2] < self.bottom_z:
+            return False
+        diff = point - self.center
+        return float(np.dot(diff, diff)) <= self.radius ** 2
+
+    def get_random_point(self):
+        """
+        Uniform sample inside the dome (upper part of the ball). Samples the full
+        ball via the cube-root method and rejects points below the surface, so
+        the result is uniform over the clipped region.
+        """
+        while True:
+            direction = self._rng.standard_normal(3)
+            direction /= np.linalg.norm(direction)
+            r = self.radius * (self._rng.random() ** (1.0 / 3.0))
+            point = self.center + r * direction
+            if point[2] >= self.bottom_z:
+                return point
+
+    def get_atoms_specie_inside_cell(self, atoms, specie):
+        """
+        Vectorized: indices of atoms whose symbol is in ``specie`` and whose
+        position is inside the dome (within the ball and above the surface).
+        Atoms that drifted below the surface (absorbed into the support) are
+        excluded, so they are never selected for deletion.
+        """
+        if len(atoms) == 0:
+            return np.empty(0, dtype=int)
+        symbols = np.asarray(atoms.get_chemical_symbols())
+        if isinstance(specie, str):
+            species_list = [specie]
+        else:
+            species_list = list(specie)
+        species_mask = np.isin(symbols, species_list)
+        diff = atoms.positions - self.center
+        within = np.einsum('ij,ij->i', diff, diff) <= self.radius ** 2
+        above = atoms.positions[:, 2] >= self.bottom_z
+        return np.where(species_mask & within & above)[0]
+
+    def calculate_volume(self, atoms):
+        """
+        Estimate the free volume of the dome: sample the full ball, keep points
+        above the surface, then exclude points covered by an atom (per-radius
+        cKDTree nearest-atom query). The free fraction is normalised by the full
+        ball sample count, so ``volume`` is the free dome volume in absolute
+        units.
+        """
+        pts = self._sample_sphere_points(self.mc_sample_points)
+        above = pts[:, 2] >= self.bottom_z
+        pts = pts[above]
+
+        n_atoms = len(atoms)
+        if n_atoms == 0:
+            dome_fraction = float(np.count_nonzero(above)) / self.mc_sample_points
+            self.volume = dome_fraction * self.sphere_volume
+            return
+
+        symbols = atoms.get_chemical_symbols()
+        radii = np.fromiter(
+            (self.species_radii[s] for s in symbols),
+            dtype=float, count=n_atoms,
+        )
+        positions = atoms.positions
+
+        covered = np.zeros(len(pts), dtype=bool)
+        for r in np.unique(radii):
+            if r <= 0.0:
+                continue
+            mask = radii == r
+            tree = cKDTree(positions[mask])
+            dists, _ = tree.query(pts, k=1, distance_upper_bound=float(r))
+            covered |= np.isfinite(dists)
+
+        free_fraction = float(np.count_nonzero(~covered)) / self.mc_sample_points
+        self.volume = free_fraction * self.sphere_volume

--- a/tests/test_dome_cell.py
+++ b/tests/test_dome_cell.py
@@ -1,0 +1,111 @@
+"""Tests for DomeCell: a hemispherical insertion region centered on a supported
+nanoparticle, truncated at the support surface (z >= bottom_z).
+
+These guard the supported-NP requirement: insertions stay on/around the particle
+(and its metal-support rim), not on the bare support far away, and never below
+the surface.
+
+Run with: python -m pytest tests/test_dome_cell.py -v
+"""
+import numpy as np
+import pytest  # noqa: F401
+from ase import Atoms, Atom
+
+from mcpy.cell import DomeCell
+
+BOTTOM_Z = 0.0
+VACUUM = 1.0
+RADII = {'Al': 1.0, 'Ag': 1.0, 'O': 0.0}
+
+# Ag particle deliberately off-center in xy (x=14) so its centroid differs from
+# the whole-system center, and low/tall enough that the enclosing ball dips below
+# the surface (so the z-clip is actually exercised).
+AG_POS = np.array([
+    [14.0, 10.0, 0.5],
+    [14.0, 10.0, 5.0],
+    [16.0, 10.0, 2.5],
+    [12.0, 10.0, 2.5],
+    [14.0, 12.0, 2.5],
+    [14.0, 8.0, 2.5],
+])
+
+
+def make_supported():
+    """Flat Al support layer at z=0 with an off-center Ag cluster above it."""
+    xs = np.linspace(1.0, 19.0, 7)
+    support = [(x, y, 0.0) for x in xs for y in xs]
+    positions = support + [tuple(p) for p in AG_POS]
+    symbols = ['Al'] * len(support) + ['Ag'] * len(AG_POS)
+    return Atoms(symbols, positions=positions, cell=[20, 20, 20], pbc=True)
+
+
+def make_cell():
+    return DomeCell(make_supported(), particle_species='Ag', bottom_z=BOTTOM_Z,
+                    vacuum=VACUUM, species_radii=RADII, seed=0)
+
+
+def test_center_is_particle_centroid():
+    """Dome centers on the particle, not the whole-system center of mass."""
+    cell = make_cell()
+    np.testing.assert_allclose(cell.center, AG_POS.mean(axis=0), atol=1e-9)
+
+
+def test_radius_covers_particle_plus_vacuum():
+    cell = make_cell()
+    expected = np.linalg.norm(AG_POS - AG_POS.mean(axis=0), axis=1).max() + VACUUM
+    assert cell.radius == pytest.approx(expected)
+
+
+def test_sampled_points_are_inside():
+    """Every sampled point passes is_point_inside (region self-consistency)."""
+    cell = make_cell()
+    for _ in range(2000):
+        assert cell.is_point_inside(cell.get_random_point())
+
+
+def test_sampled_points_above_surface():
+    cell = make_cell()
+    for _ in range(2000):
+        assert cell.get_random_point()[2] >= BOTTOM_Z
+
+
+def test_far_support_point_is_outside():
+    """A point on the bare support far from the particle is excluded."""
+    cell = make_cell()
+    assert not cell.is_point_inside(np.array([1.0, 1.0, 0.1]))
+
+
+def test_subsurface_point_is_outside():
+    """A point below the support surface is excluded even if within the ball."""
+    cell = make_cell()
+    below = cell.center.copy()
+    below[2] = BOTTOM_Z - 0.5
+    assert not cell.is_point_inside(below)
+
+
+def test_inserted_atom_is_counted():
+    cell = make_cell()
+    atoms = make_supported()
+    for _ in range(500):
+        trial = atoms.copy()
+        trial.append(Atom('O', position=cell.get_random_point()))
+        idx = cell.get_atoms_specie_inside_cell(trial, ['O'])
+        assert len(idx) == 1
+
+
+def test_subsurface_atom_is_not_counted():
+    """O absorbed below the surface is kept (not exchangeable with reservoir)."""
+    cell = make_cell()
+    atoms = make_supported()
+    atoms.append(Atom('O', position=[cell.center[0], cell.center[1], BOTTOM_Z - 0.5]))
+    idx = cell.get_atoms_specie_inside_cell(atoms, ['O'])
+    assert len(idx) == 0
+
+
+def test_dome_volume_is_a_fraction_of_the_ball():
+    """Free dome volume is positive and below the full enclosing ball volume."""
+    cell = make_cell()
+    atoms = make_supported()
+    cell.calculate_volume(atoms)
+    full_ball = (4.0 / 3.0) * np.pi * cell.radius ** 3
+    assert 0.0 < cell.get_volume() < full_ball


### PR DESCRIPTION
 ## Add DomeCell for supported-nanoparticle GCMC

  ### Motivation
  `CustomCell` samples insertion points uniformly across the entire box above the
  support, so in a supported-nanoparticle GCMC the inserted species lands anywhere
  on the bare support, far from the particle. There was no way to keep trial
  insertions on the nanoparticle itself.

  ### What this adds
  `DomeCell`, a hemispherical insertion region centered on the supported particle:
  the ball of radius `R` around the particle centroid, truncated at the support
  surface (`z >= bottom_z`). Trial insertions stay on and around the particle and
  its metal/support contact rim, instead of spreading across the support.

  It subclasses `SphericalCell` (reusing the Monte Carlo free-volume machinery)
  but differs in two ways that matter for a supported slab:
  * it centers on a chosen particle species (e.g. `Ag`) rather than the
    whole-system center of mass, and
  * it does not translate the atoms, and it clips the region at the support
    surface.

  ### Changes
  * `mcpy/cell/dome_cell.py`: new `DomeCell`, exported from `mcpy.cell`.
  * `tests/test_dome_cell.py`: 9 tests (centers on the particle not the COM,
    sampled points stay inside and above the surface, far/bare-support and
    subsurface points excluded, inserted atoms counted, dome free volume sane).
  * `examples/plot_supported_np.py`: showcase render of a supported-NP trajectory
    (single depth-shaded 3/4 view; adsorbates are atoms appended after frame 0).

  ### Usage
  ```python
  from mcpy.cell import DomeCell

  scell = DomeCell(atoms, particle_species='Ag', bottom_z=surface_z, vacuum=3.0,
                   species_radii={'Ag': 2.068, 'O': 0, 'Al': 3})
