### PR TITLE
Revert GCMC de Broglie count to total atom count

### DIFF
--- a/docs/gcmc_acceptance_convention.rst
+++ b/docs/gcmc_acceptance_convention.rst
@@ -1,0 +1,152 @@
+GCMC acceptance: the de Broglie particle count
+==============================================
+
+This note records a deliberate, non-obvious convention in the grand-canonical
+acceptance test, the discussion behind it, and the change history. It exists so
+the choice is not silently "fixed" by a future contributor who (correctly)
+notices it departs from the textbook/LAMMPS form.
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+The acceptance criterion
+------------------------
+
+Insertion and deletion are accepted with the de Broglie (grand-canonical)
+probabilities (see :class:`mcpy.ensembles.GrandCanonicalEnsemble` and
+:mod:`mcpy.utils.set_unit_constant`):
+
+.. math::
+
+   p_\text{ins} = \frac{V}{(N+1)\,\Lambda^3}\;
+                  e^{-\beta(\Delta E - \mu)},
+   \qquad
+   p_\text{del} = \frac{N\,\Lambda^3}{V}\;
+                  e^{-\beta(\Delta E + \mu)} .
+
+``V`` is the cell free volume, :math:`\Lambda` the thermal de Broglie
+wavelength of the exchanged species, :math:`\mu` its chemical potential, and
+``N`` the particle count fed to the combinatorial factor. **The question this
+note settles is: which ``N``?**
+
+
+Two conventions for ``N``
+-------------------------
+
+total atom count (the convention mcpy uses)
+    ``N = len(atoms)`` before the move: every atom of every species, including
+    the fixed substrate. This is what ``do_gcmc_step`` and
+    ``BatchedReplicaExchange`` pass today (``self.n_atoms`` / ``r.n_atoms``).
+
+per-species exchangeable count (textbook / LAMMPS)
+    ``N`` = number of atoms *of the exchanged species* inside the insertion
+    region (the move's cell). This is the physically standard choice.
+
+The physically correct quantity is the **per-species** count. The de Broglie
+factor is the ideal-gas combinatorial term: the :math:`1/N!` indistinguishability
+correction applies only among identical, interchangeable particles, and only to
+the population that shares the insertion volume ``V``. The total atom count
+mixes in distinguishable species and the fixed substrate, which do not belong in
+that factor. The interaction with all those atoms enters the acceptance through
+:math:`\Delta E` (the total potential energy change), not through ``N``.
+
+
+What LAMMPS does
+----------------
+
+``fix gcmc`` (``src/MC/fix_gcmc.cpp``) uses exactly the per-species, in-region
+count. Its acceptance lines are::
+
+    // insertion
+    random < zz*volume*exp(-beta*insertion_energy)/(ngas+1)
+    // deletion
+    random < ngas*exp(beta*deletion_energy)/(zz*volume)
+    // activity
+    zz = exp(beta*chemical_potential)/pow(lambda,3.0);
+
+so :math:`p_\text{ins} = V/((n_\text{gas}+1)\Lambda^3)\,e^{-\beta(\Delta U-\mu)}`,
+identical in form to mcpy. ``ngas`` is built by ``update_gas_atoms_list()``,
+which keeps only atoms passing both the group/type filter (``mask[i] & groupbit``,
+restricted to the exchanged type) and the region test (``region->match(...)``).
+LAMMPS also confirms two further conventions mcpy shares or should note:
+
+- ``mu`` is the **full** chemical potential, including the ideal/:math:`\Lambda`
+  term (``zz = exp(beta*mu)/lambda^3``). So ``mu`` must be referenced on the
+  calculator's absolute energy scale (e.g. an O\ :sub:`2` gas reference at the
+  target ``T`` and ``p``).
+- ``volume`` is the **geometric** region volume (MC-sampled only to handle odd
+  region shapes); it does **not** exclude space occupied by atoms. mcpy instead
+  uses a *free* volume (``cell_volume * (1 - occupied_fraction)``) while still
+  sampling insertion points over the full cell box — an internal inconsistency
+  LAMMPS does not have.
+
+Sources: https://docs.lammps.org/fix_gcmc.html and
+https://github.com/lammps/lammps/blob/develop/src/MC/fix_gcmc.cpp
+
+
+Why mcpy keeps the total atom count
+-----------------------------------
+
+**Reproducibility.** The group's entire body of GCMC work (including the
+forthcoming Ag-oxidation study) was produced with the total-atom-count
+convention. Switching to the per-species count shifts the *effective* chemical
+potential by
+
+.. math::
+
+   \Delta\mu_\text{eff} = k_BT \,\ln\!\frac{N_\text{total}+1}{N_\text{species}+1},
+
+which for a few-thousand-atom substrate with tens of exchanged atoms is
+**~0.1-0.2 eV toward insertion** at typical temperatures. Concretely, after the
+per-species change an oxide phase boundary moved from roughly :math:`\Delta\mu
+\approx -0.5` eV to :math:`\approx -0.3` eV, and oxygen kept inserting well into
+the reducing regime. Keeping the original convention keeps every simulation on
+one consistent footing; the per-species count would require re-running and
+re-calibrating ``mu`` across all prior work.
+
+This is a reproducibility choice, **not** a claim that the total count is more
+correct. If you start a fresh study with no need to match prior runs, prefer the
+per-species count (and recalibrate ``mu`` against a gas reference).
+
+
+Side effect that the total count happens to mask
+------------------------------------------------
+
+With the per-species count there is a runaway failure mode for species that
+dissolve below the cell floor. ``CustomCell.get_atoms_specie_inside_cell``
+excludes atoms with ``z < bottom_z`` (subsurface, "absorbed"), so such atoms are
+neither counted nor eligible for deletion. Under the per-species convention this
+undercount inflates :math:`V/((N+1)\Lambda^3)` and insertion stays favored no
+matter how negative ``mu`` is — one-way accumulation decoupled from ``mu``.
+
+The total-atom-count convention sidesteps this: as oxygen accumulates anywhere
+(surface *or* subsurface), ``N_total`` grows, which suppresses further insertion.
+The system is self-limiting. The buried-O irreversibility still exists (buried O
+is never a deletion candidate), but it no longer drives runaway uptake.
+
+
+Change history
+--------------
+
+- ``668e732`` / earlier — both ensembles born using the total atom count.
+- ``adcc15b`` — switched ``GrandCanonicalEnsemble`` to the per-species count.
+- ``9a15425`` — switched ``BatchedReplicaExchange`` to the per-species count.
+- *this change* — reverted both back to the total atom count for reproducibility,
+  and recorded the discussion here.
+
+
+Where this lives in the code and tests
+--------------------------------------
+
+- ``mcpy/ensembles/grand_canonical_ensemble.py`` — ``do_gcmc_step`` passes
+  ``self.n_atoms`` to ``_acceptance_condition``.
+- ``mcpy/ensembles/batched_replica_exchange.py`` — ``_batched_single_move``
+  passes ``r.n_atoms``.
+- ``tests/test_acceptance.py`` — ``test_do_gcmc_step_feeds_total_atom_count``
+  guards the convention; ``test_total_vs_perspecies_count_shifts_effective_mu``
+  and ``test_perspecies_count_inserts_where_total_rejects`` quantify the gap.
+- ``tests/test_custom_cell_region.py`` —
+  ``test_subsurface_oxygen_is_excluded_from_deletion_candidates`` documents the
+  buried-O caveat.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,7 @@ the hybrid GCMC method it implements (see :doc:`bibliography`).
    species_radii
    moves
    calculators
+   gcmc_acceptance_convention
 
 .. toctree::
    :caption: Tutorials

--- a/mcpy/ensembles/batched_replica_exchange.py
+++ b/mcpy/ensembles/batched_replica_exchange.py
@@ -200,12 +200,7 @@ class BatchedReplicaExchange:
                 result if isinstance(result, tuple) else (result, 0, None)
             )
             if atoms_new:
-                n_species_before = None
-                if delta_particles != 0:
-                    n_species_before = len(
-                        r.move_selector.get_atoms_specie_inside_cell(r.atoms, species)
-                    ) - delta_particles
-                trial_meta[i] = (delta_particles, species, n_species_before)
+                trial_meta[i] = (delta_particles, species)
             # else: move couldn't propose — atoms unchanged, snapshot harmless
 
         viable = [i for i in active if i in trial_meta]
@@ -216,11 +211,14 @@ class BatchedReplicaExchange:
         energies = self.calculator.get_potential_energies(atoms_list)
         for i, E_new in zip(viable, energies):
             r = self.replicas[i]
-            delta_particles, species, n_species_before = trial_meta[i]
+            delta_particles, species = trial_meta[i]
             delta_E = float(E_new) - r.E_old
             volume = r.move_selector.get_volume()
+            # de Broglie particle count: total atom count before the move
+            # (``r.n_atoms`` is updated only on acceptance). See
+            # docs/gcmc_acceptance_convention.rst.
             if r._acceptance_condition(delta_E, delta_particles, volume, species,
-                                       n_species_before):
+                                       r.n_atoms):
                 if r._wrap_on_accept:
                     r.atoms.wrap()
                 r.n_atoms = len(r.atoms)

--- a/mcpy/ensembles/grand_canonical_ensemble.py
+++ b/mcpy/ensembles/grand_canonical_ensemble.py
@@ -167,10 +167,12 @@ class GrandCanonicalEnsemble(BaseEnsemble):
                               delta_particles: int,
                               volume: float,
                               species: str,
-                              n_atoms_species: int = None) -> bool:
+                              n_atoms: int = None) -> bool:
         """Metropolis / de-Broglie acceptance test for displacement, insertion,
-        and deletion moves. ``n_atoms_species`` is the per-species exchangeable
-        count before the move (required for insertion/deletion)."""
+        and deletion moves. ``n_atoms`` is the particle count fed to the de
+        Broglie combinatorial factor; the GCMC loop passes the total atom count
+        before the move (the original convention, kept for consistency with the
+        group's published runs -- see docs/gcmc_acceptance_convention.rst)."""
         if delta_particles == 0:
             if potential_diff <= 0:
                 return True
@@ -178,7 +180,7 @@ class GrandCanonicalEnsemble(BaseEnsemble):
             return p > self.rng_acceptance.get_uniform()
 
         if delta_particles == 1:  # insertion
-            db_term = self.units.de_broglie_insertion(volume, n_atoms_species, species)
+            db_term = self.units.de_broglie_insertion(volume, n_atoms, species)
             exp_term = np.exp(-self.units.beta * (potential_diff - self._mu[species]))
             p = db_term * exp_term
             self.logger.debug(
@@ -187,7 +189,7 @@ class GrandCanonicalEnsemble(BaseEnsemble):
                 self.units.lambda_dbs[species], p, self.units.beta, exp_term,
                 potential_diff - self._mu[species], potential_diff, delta_particles)
         elif delta_particles == -1:  # deletion
-            db_term = self.units.de_broglie_deletion(volume, n_atoms_species, species)
+            db_term = self.units.de_broglie_deletion(volume, n_atoms, species)
             exp_term = np.exp(-self.units.beta * (potential_diff + self._mu[species]))
             p = db_term * exp_term
             self.logger.debug(
@@ -222,21 +224,14 @@ class GrandCanonicalEnsemble(BaseEnsemble):
                 # failure so it won't depress the acceptance ratio.
                 continue
 
-            # Per-species exchangeable count before the move, for the de Broglie
-            # factor. The move already mutated atoms in place, so subtract
-            # delta_particles. Read it now, before compute_energy relaxes the
-            # geometry and can nudge the new atom out of the cell region.
-            n_species_before = None
-            if delta_particles != 0:
-                n_species_before = len(
-                    self.move_selector.get_atoms_specie_inside_cell(atoms, species)
-                ) - delta_particles
-
             E_new = self.compute_energy(atoms)
             delta_E = E_new - self.E_old
             volume = self.move_selector.get_volume()
-            if self._acceptance_condition(delta_E, delta_particles, volume, species,
-                                          n_species_before):
+            # de Broglie particle count: total atom count before the move.
+            # ``self.n_atoms`` is updated only on acceptance, so it still holds
+            # the pre-move total here. See docs/gcmc_acceptance_convention.rst.
+            if self._acceptance_condition(delta_E, delta_particles, volume,
+                                          species, self.n_atoms):
                 if self._wrap_on_accept:
                     atoms.wrap()
                 self.n_atoms = len(atoms)

--- a/mcpy/moves/move_selector.py
+++ b/mcpy/moves/move_selector.py
@@ -69,10 +69,6 @@ class MoveSelector:
     def get_volume(self):
         return self.move_list[self.to_use].get_volume()
 
-    def get_atoms_specie_inside_cell(self, atoms, species):
-        """Indices of ``species`` atoms inside the last-selected move's cell."""
-        return self.move_list[self.to_use].cell.get_atoms_specie_inside_cell(atoms, species)
-
     def calculate_volume(self, atoms):
         return self.move_list[self.to_use].calculate_volume(atoms)
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -15,6 +15,7 @@ import types
 
 import numpy as np
 import pytest
+from ase import Atoms
 
 from mcpy.ensembles.canonical_ensemble import CanonicalEnsemble
 from mcpy.ensembles.grand_canonical_ensemble import GrandCanonicalEnsemble
@@ -99,11 +100,11 @@ def test_gcmc_insertion_favoured_by_high_mu():
     # Large positive mu drives the acceptance probability above 1 -> always accept.
     e = _gcmc(300.0, mu=0.5, rng_value=0.999)
     assert e._acceptance_condition(0.0, 1, volume=1000.0, species="H",
-                                   n_atoms_species=0)
+                                   n_atoms=0)
     # Strongly negative mu suppresses insertion -> reject against a mid draw.
     e_rej = _gcmc(300.0, mu=-0.5, rng_value=0.5)
     assert not e_rej._acceptance_condition(0.0, 1, volume=1000.0, species="H",
-                                           n_atoms_species=0)
+                                           n_atoms=0)
 
 
 def test_gcmc_insertion_probability_formula():
@@ -114,9 +115,9 @@ def test_gcmc_insertion_probability_formula():
     # Choose a draw straddling the expected probability.
     below = _gcmc(300.0, mu=-0.3, rng_value=expected * 0.99)
     above = _gcmc(300.0, mu=-0.3, rng_value=min(expected * 1.01, 1.0))
-    assert below._acceptance_condition(diff, 1, volume, "H", n_atoms_species=n)
+    assert below._acceptance_condition(diff, 1, volume, "H", n_atoms=n)
     if expected < 1.0:
-        assert not (above._acceptance_condition(diff, 1, volume, "H", n_atoms_species=n))
+        assert not (above._acceptance_condition(diff, 1, volume, "H", n_atoms=n))
 
 
 def test_gcmc_deletion_uses_opposite_mu_sign():
@@ -126,13 +127,102 @@ def test_gcmc_deletion_uses_opposite_mu_sign():
     expected = (e.units.de_broglie_deletion(volume, n, "H")
                 * np.exp(-e.units.beta * (diff + e._mu["H"])))
     below = _gcmc(300.0, mu=-0.3, rng_value=expected * 0.99)
-    assert below._acceptance_condition(diff, -1, volume, "H", n_atoms_species=n)
+    assert below._acceptance_condition(diff, -1, volume, "H", n_atoms=n)
 
 
 def test_gcmc_rejects_unexpected_delta_particles():
     e = _gcmc(300.0, mu=0.0, rng_value=0.5)
     with pytest.raises(ValueError):
         e._acceptance_condition(0.0, 2, volume=1000.0, species="H")
+
+
+# --------------------------------------------------------------------------
+# Total vs per-species de-Broglie count (documents the convention choice)
+#
+# The de Broglie combinatorial factor needs a particle count N. mcpy uses the
+# *total* atom count (len(atoms): substrate + every species) -- the original
+# convention, kept for consistency with the group's published runs. The
+# physically standard / LAMMPS choice is the per-species exchangeable count in
+# the insertion region. Both go through the same _acceptance_condition; only
+# the n_atoms argument differs. These tests quantify the gap so the decision
+# stays recorded in code. See docs/gcmc_acceptance_convention.rst.
+# --------------------------------------------------------------------------
+
+def _gcmc_sp(temperature, mu, rng_value, species):
+    e = GrandCanonicalEnsemble.__new__(GrandCanonicalEnsemble)
+    e.units = SetUnits("metal", temperature, [species])
+    e._mu = {species: mu}
+    e.rng_acceptance = FixedRNG(rng_value)
+    e.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
+    e.move_selector = types.SimpleNamespace(get_name=lambda: "dummy")
+    return e
+
+
+def test_total_vs_perspecies_count_shifts_effective_mu():
+    """For identical (V, dE, mu, T) the insertion probability scales by
+    (N_total+1)/(N_species+1). Since N_total (all atoms) >> N_species (O in the
+    cell), the per-species choice would insert far more readily -- an effective
+    chemical potential shift of +kT*ln((N_total+1)/(N_species+1)). mcpy keeps
+    the total count, so this shift is exactly what would change if we switched."""
+    units = SetUnits("metal", 500.0, ["O"])
+    volume = 1500.0
+    n_total, n_species = 1000, 20  # total atoms vs O atoms inside the cell
+    p_total = units.de_broglie_insertion(volume, n_total, "O")
+    p_species = units.de_broglie_insertion(volume, n_species, "O")
+    assert p_species > p_total
+    np.testing.assert_allclose(p_species / p_total, (n_total + 1) / (n_species + 1))
+    dmu = np.log((n_total + 1) / (n_species + 1)) / units.beta  # eV
+    assert dmu > 0
+
+
+def test_perspecies_count_inserts_where_total_rejects():
+    """Same trial and same RNG draw: the per-species count would accept an
+    insertion that the total-atom count (mcpy's convention) rejects."""
+    volume, diff, mu, T = 1500.0, 0.0, -0.3, 500.0
+    n_total, n_species = 1000, 20
+    units = SetUnits("metal", T, ["O"])
+    exp_term = np.exp(-units.beta * (diff - mu))
+    p_total = units.de_broglie_insertion(volume, n_total, "O") * exp_term
+    p_species = units.de_broglie_insertion(volume, n_species, "O") * exp_term
+    assert p_total < 1.0  # total-count path is probabilistic, not auto-accept
+    draw = 0.5 * (p_total + min(p_species, 1.0))  # between the two -> they disagree
+    e_species = _gcmc_sp(T, mu, rng_value=draw, species="O")
+    e_total = _gcmc_sp(T, mu, rng_value=draw, species="O")
+    assert e_species._acceptance_condition(diff, 1, volume, "O", n_atoms=n_species)
+    assert not e_total._acceptance_condition(diff, 1, volume, "O", n_atoms=n_total)
+
+
+def test_do_gcmc_step_feeds_total_atom_count():
+    """Restored-convention guard: do_gcmc_step passes the TOTAL atom count to
+    the de Broglie factor, not the per-species in-cell count. If someone
+    re-introduces the per-species count, this fails -- flip it deliberately and
+    update docs/gcmc_acceptance_convention.rst, do not change it silently."""
+    e = GrandCanonicalEnsemble.__new__(GrandCanonicalEnsemble)
+    atoms = Atoms('Ag5', positions=[[i, 0.0, 0.0] for i in range(5)])
+    e._atoms = atoms
+    e.E_old = 0.0
+    e.n_atoms = len(atoms)          # 5 total atoms before the move
+    e.compute_energy = lambda a: 0.0
+
+    def _insert(a):                 # mutates in place, returns (atoms, +1, 'O')
+        a += Atoms('O', positions=[[0.0, 0.0, 9.0]])
+        return a, 1, 'O'
+
+    e.move_selector = types.SimpleNamespace(
+        n_moves=1, do_trial_move=_insert, get_volume=lambda: 100.0,
+    )
+
+    captured = {}
+
+    def _capture(delta_E, delta_particles, volume, species, n_atoms=None):
+        captured['n_atoms'] = n_atoms
+        return False                # reject -> only the rollback path runs
+
+    e._acceptance_condition = _capture
+    e.do_gcmc_step()
+
+    # Total count (5), not the per-species in-cell O count (0 before insertion).
+    assert captured['n_atoms'] == 5
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_custom_cell_region.py
+++ b/tests/test_custom_cell_region.py
@@ -3,9 +3,10 @@ Tests that CustomCell's membership tests (``is_point_inside``,
 ``get_atoms_specie_inside_cell``) agree with the region actually sampled by
 ``get_random_point``. For non-orthogonal (e.g. hexagonal fcc111) cells the
 in-plane lattice vector has an off-diagonal component, so an axis-aligned
-box test mis-classifies ~25% of sampled points. That undercount made
-``n_species_before`` go negative and ``de_broglie_insertion`` return inf,
-causing unconditional acceptance of insertions.
+box test mis-classifies ~25% of sampled points. That misclassification
+corrupts deletion-candidate selection and the ``InsertionMove`` minimum-distance
+bias (and, historically, under a per-species de Broglie count, the acceptance
+factor itself -- see docs/gcmc_acceptance_convention.rst).
 
 Run with: python -m pytest tests/test_custom_cell_region.py -v
 """
@@ -38,3 +39,28 @@ def test_inserted_atom_is_counted():
         trial.append(Atom('O', position=cell.get_random_point()))
         idx = cell.get_atoms_specie_inside_cell(trial, ['O'])
         assert len(idx) == 1
+
+
+def test_subsurface_oxygen_is_excluded_from_deletion_candidates():
+    """O that drifts below the cell floor (``z < bottom_z``, i.e. absorbed into
+    the subsurface) is deliberately excluded from ``get_atoms_specie_inside_cell``.
+    DeletionMove draws its candidates from that list, so buried O can never be
+    selected for deletion and accumulates irreversibly -- a caveat of the
+    cell-restricted region independent of the de Broglie count convention. See
+    docs/gcmc_acceptance_convention.rst.
+    """
+    atoms, cell = make_cell()
+    # Same xy (inside the footprint); one above the floor, one 1 A below it.
+    inside = np.array([0.5, 0.5, 0.5]) @ cell.dimensions + cell.offset
+    above = inside.copy()
+    below = inside.copy()
+    below[2] = cell.offset[2] - 1.0  # below bottom_z -> subsurface
+
+    atoms.append(Atom('O', position=above))
+    atoms.append(Atom('O', position=below))
+
+    counted = cell.get_atoms_specie_inside_cell(atoms, ['O'])
+    total_o = int(np.count_nonzero(np.asarray(atoms.get_chemical_symbols()) == 'O'))
+
+    assert total_o == 2       # both O are present in the structure
+    assert len(counted) == 1  # only the above-floor O is a deletion candidate


### PR DESCRIPTION
## Summary

Restores the original convention of feeding the **total atom count** (`len(atoms)`, substrate + all species) into the de Broglie combinatorial factor for insertion/deletion acceptance, reverting `adcc15b` (`GrandCanonicalEnsemble`) and `9a15425` (`BatchedReplicaExchange`).

## Why

The per-species, in-cell count those commits introduced is the physically standard / LAMMPS choice, but it shifts the effective chemical potential by `kT*ln((N_total+1)/(N_species+1))` (~0.1-0.2 eV toward insertion), moving phase boundaries and over-oxidizing relative to all of the group's prior simulations. Reverting keeps every run on one consistent footing.

This is a **reproducibility** choice, not a correctness claim. The full discussion (formula, LAMMPS `fix_gcmc` comparison, effective-μ shift, μ reference requirement, subsurface-O caveat, change history) is recorded in `docs/gcmc_acceptance_convention.rst`.

## What changed

- `do_gcmc_step` / `_batched_single_move` pass the total atom count (`self.n_atoms` / `r.n_atoms`).
- `_acceptance_condition` argument renamed `n_atoms_species` -> `n_atoms`.
- Dropped the now-unused `MoveSelector.get_atoms_specie_inside_cell` helper.
- New doc `docs/gcmc_acceptance_convention.rst` (added to the toctree).

## Testing

- `test_do_gcmc_step_feeds_total_atom_count` — regression guard so the convention can't flip silently.
- `test_total_vs_perspecies_count_shifts_effective_mu` / `test_perspecies_count_inserts_where_total_rejects` — quantify the gap between conventions.
- `test_subsurface_oxygen_is_excluded_from_deletion_candidates` — documents the buried-O caveat.
- 70 non-torch tests pass; flake8 clean. (`test_calculator_gcmc_equivalence.py` needs the GPU/torch env.)
